### PR TITLE
Feat: 유저 이번 시즌 러닝 조회

### DIFF
--- a/src/main/java/run/backend/domain/crew/controller/CrewController.java
+++ b/src/main/java/run/backend/domain/crew/controller/CrewController.java
@@ -114,9 +114,9 @@ public class CrewController {
 
     @GetMapping("/events/upcoming")
     @Operation(summary = "upcoming 일정 조회", description = "크루의 upcoming 일정 조회하는 API 입니다.")
-    public CommonResponse<CrewUpcomingEventResponse> getUpcomingEvent(@MemberCrew Crew crew) {
+    public CommonResponse<EventResponseDto> getUpcomingEvent(@MemberCrew Crew crew) {
 
-        CrewUpcomingEventResponse response = crewEventService.getCrewUpcomingEvent(crew);
+        EventResponseDto response = crewEventService.getCrewUpcomingEvent(crew);
         return new CommonResponse<>("크루 다가오는 일정 조회 성공", response);
     }
 

--- a/src/main/java/run/backend/domain/crew/dto/response/EventResponseDto.java
+++ b/src/main/java/run/backend/domain/crew/dto/response/EventResponseDto.java
@@ -2,7 +2,7 @@ package run.backend.domain.crew.dto.response;
 
 import java.util.List;
 
-public record CrewUpcomingEventResponse(
+public record EventResponseDto(
         List<EventProfileResponse> eventProfiles
 ) {
 }

--- a/src/main/java/run/backend/domain/crew/service/CrewEventService.java
+++ b/src/main/java/run/backend/domain/crew/service/CrewEventService.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import run.backend.domain.crew.dto.common.DayStatusDto;
 import run.backend.domain.crew.dto.response.CrewMonthlyCanlendarResponse;
-import run.backend.domain.crew.dto.response.CrewUpcomingEventResponse;
+import run.backend.domain.crew.dto.response.EventResponseDto;
 import run.backend.domain.crew.dto.response.CrewWeeklyEventResponse;
 import run.backend.domain.crew.dto.response.EventProfileResponse;
 import run.backend.domain.crew.entity.Crew;
@@ -52,13 +52,13 @@ public class CrewEventService {
         return new CrewMonthlyCanlendarResponse(statusMap);
     }
 
-    public CrewUpcomingEventResponse getCrewUpcomingEvent(Crew crew) {
+    public EventResponseDto getCrewUpcomingEvent(Crew crew) {
 
         LocalDate today = LocalDate.now();
 
         List<Event> events = eventRepository.findAllByCrewAndDateAfter(crew, today);
         List<EventProfileResponse> eventProfiles = eventMapper.toEventProfileList(events);
 
-        return new CrewUpcomingEventResponse(eventProfiles);
+        return new EventResponseDto(eventProfiles);
     }
 }

--- a/src/main/java/run/backend/domain/event/entity/JoinEvent.java
+++ b/src/main/java/run/backend/domain/event/entity/JoinEvent.java
@@ -1,19 +1,29 @@
 package run.backend.domain.event.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import run.backend.domain.member.entity.Member;
 import run.backend.global.common.BaseEntity;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @Table(name = "join_events")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE join_events SET deleted_at = NOW() WHERE id = ?")
+@Where(clause = "deleted_at IS NULL")
 public class JoinEvent extends BaseEntity {
 
     @Id
@@ -39,9 +49,5 @@ public class JoinEvent extends BaseEntity {
         this.isRunning = false;
         this.member = member;
         this.event = event;
-    }
-
-    public void softDelete() {
-        this.setDeletedAt(LocalDateTime.now());
     }
 }

--- a/src/main/java/run/backend/domain/event/entity/PeriodicEvent.java
+++ b/src/main/java/run/backend/domain/event/entity/PeriodicEvent.java
@@ -5,6 +5,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import run.backend.domain.crew.entity.Crew;
 import run.backend.domain.event.enums.RepeatCycle;
 import run.backend.domain.event.enums.WeekDay;
@@ -18,6 +20,8 @@ import java.time.LocalTime;
 @Getter
 @Table(name = "periodic_events")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE periodic_events SET deleted_at = NOW() WHERE id = ?")
+@Where(clause = "deleted_at IS NULL")
 public class PeriodicEvent extends BaseEntity {
 
     @Id
@@ -110,9 +114,5 @@ public class PeriodicEvent extends BaseEntity {
         if (runningCaptain != null) {
             this.member = runningCaptain;
         }
-    }
-
-    public void softDelete() {
-        this.setDeletedAt(java.time.LocalDateTime.now());
     }
 }

--- a/src/main/java/run/backend/domain/event/repository/JoinEventRepository.java
+++ b/src/main/java/run/backend/domain/event/repository/JoinEventRepository.java
@@ -29,12 +29,13 @@ public interface JoinEventRepository extends JpaRepository<JoinEvent, Long> {
                                                   @Param("startDate") LocalDate startDate, 
                                                   @Param("endDate") LocalDate endDate);
 
-    @Query("SELECT new run.backend.domain.crew.dto.response.EventProfileResponse(" +
-           "e.id, e.title, e.date, e.startTime, e.endTime, e.expectedParticipants) " +
-           "FROM JoinEvent j JOIN j.event e " +
-           "WHERE j.member = :member " +
-           "AND e.date >= :startDate AND e.date <= :endDate " +
-           "AND e.status = 'COMPLETED' ORDER BY e.date DESC")
+    @Query("""
+        SELECT new run.backend.domain.crew.dto.response.EventProfileResponse(\
+        e.id, e.title, e.date, e.startTime, e.endTime, e.expectedParticipants) \
+        FROM JoinEvent j JOIN j.event e \
+        WHERE j.member = :member \
+        AND e.date >= :startDate AND e.date <= :endDate \
+        AND e.status = 'COMPLETED' ORDER BY e.date DESC""")
     List<EventProfileResponse> findMonthlyCompletedEvents(@Param("member") Member member,
                                                              @Param("startDate") LocalDate startDate, 
                                                              @Param("endDate") LocalDate endDate);

--- a/src/main/java/run/backend/domain/event/repository/JoinEventRepository.java
+++ b/src/main/java/run/backend/domain/event/repository/JoinEventRepository.java
@@ -2,14 +2,14 @@ package run.backend.domain.event.repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import run.backend.domain.crew.dto.response.EventProfileResponse;
 import run.backend.domain.event.entity.Event;
 import run.backend.domain.event.entity.JoinEvent;
 import run.backend.domain.member.entity.Member;
-
-import java.util.Optional;
 
 public interface JoinEventRepository extends JpaRepository<JoinEvent, Long> {
     
@@ -19,14 +19,25 @@ public interface JoinEventRepository extends JpaRepository<JoinEvent, Long> {
     @Query("SELECT j FROM JoinEvent j WHERE j.event = :event")
     List<JoinEvent> findByEvent(@Param("event") Event event);
     
-    @Query("SELECT j FROM JoinEvent j WHERE j.event = :event AND j.isRunning = true")
+    @Query("SELECT j FROM JoinEvent j WHERE j.event = :event AND j.event.status = 'COMPLETED'")
     List<JoinEvent> findActualParticipantsByEvent(@Param("event") Event event);
 
     @Query("SELECT j FROM JoinEvent j WHERE j.member = :member " +
-           "AND j.event.date >= :startDate AND j.event.date <= :endDate")
+           "AND j.event.date >= :startDate AND j.event.date <= :endDate " +
+           "AND j.event.status = 'COMPLETED'")
     List<JoinEvent> findMonthlyParticipatedEvents(@Param("member") Member member, 
                                                   @Param("startDate") LocalDate startDate, 
                                                   @Param("endDate") LocalDate endDate);
+
+    @Query("SELECT new run.backend.domain.crew.dto.response.EventProfileResponse(" +
+           "e.id, e.title, e.date, e.startTime, e.endTime, e.expectedParticipants) " +
+           "FROM JoinEvent j JOIN j.event e " +
+           "WHERE j.member = :member " +
+           "AND e.date >= :startDate AND e.date <= :endDate " +
+           "AND e.status = 'COMPLETED' ORDER BY e.date DESC")
+    List<EventProfileResponse> findMonthlyCompletedEvents(@Param("member") Member member,
+                                                             @Param("startDate") LocalDate startDate, 
+                                                             @Param("endDate") LocalDate endDate);
 
     boolean existsByEventAndMember(Event event, Member member);
 }

--- a/src/main/java/run/backend/domain/event/repository/JoinEventRepository.java
+++ b/src/main/java/run/backend/domain/event/repository/JoinEventRepository.java
@@ -13,22 +13,20 @@ import java.util.Optional;
 
 public interface JoinEventRepository extends JpaRepository<JoinEvent, Long> {
     
-    void deleteByEventAndMember(Event event, Member member);
-    
-    @Query("SELECT j FROM JoinEvent j WHERE j.event = :event AND j.member = :member AND j.deletedAt IS NULL")
+    @Query("SELECT j FROM JoinEvent j WHERE j.event = :event AND j.member = :member")
     Optional<JoinEvent> findByEventAndMember(@Param("event") Event event, @Param("member") Member member);
     
-    @Query("SELECT j FROM JoinEvent j WHERE j.event = :event AND j.deletedAt IS NULL")
-    List<JoinEvent> findByEventAndNotDeleted(@Param("event") Event event);
+    @Query("SELECT j FROM JoinEvent j WHERE j.event = :event")
+    List<JoinEvent> findByEvent(@Param("event") Event event);
     
-    @Query("SELECT j FROM JoinEvent j WHERE j.event = :event AND j.isRunning = true AND j.deletedAt IS NULL")
+    @Query("SELECT j FROM JoinEvent j WHERE j.event = :event AND j.isRunning = true")
     List<JoinEvent> findActualParticipantsByEvent(@Param("event") Event event);
 
-    @Query("SELECT j FROM JoinEvent j WHERE j.member = :member AND j.deletedAt IS NULL " +
+    @Query("SELECT j FROM JoinEvent j WHERE j.member = :member " +
            "AND j.event.date >= :startDate AND j.event.date <= :endDate")
     List<JoinEvent> findMonthlyParticipatedEvents(@Param("member") Member member, 
                                                   @Param("startDate") LocalDate startDate, 
                                                   @Param("endDate") LocalDate endDate);
 
-    boolean existsByEventAndMemberAndDeletedAtIsNull(Event event, Member member);
+    boolean existsByEventAndMember(Event event, Member member);
 }

--- a/src/main/java/run/backend/domain/event/repository/JoinEventRepository.java
+++ b/src/main/java/run/backend/domain/event/repository/JoinEventRepository.java
@@ -1,5 +1,6 @@
 package run.backend.domain.event.repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -22,6 +23,12 @@ public interface JoinEventRepository extends JpaRepository<JoinEvent, Long> {
     
     @Query("SELECT j FROM JoinEvent j WHERE j.event = :event AND j.isRunning = true AND j.deletedAt IS NULL")
     List<JoinEvent> findActualParticipantsByEvent(@Param("event") Event event);
+
+    @Query("SELECT j FROM JoinEvent j WHERE j.member = :member AND j.deletedAt IS NULL " +
+           "AND j.event.date >= :startDate AND j.event.date <= :endDate")
+    List<JoinEvent> findMonthlyParticipatedEvents(@Param("member") Member member, 
+                                                  @Param("startDate") LocalDate startDate, 
+                                                  @Param("endDate") LocalDate endDate);
 
     boolean existsByEventAndMemberAndDeletedAtIsNull(Event event, Member member);
 }

--- a/src/main/java/run/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/run/backend/domain/member/controller/MemberController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-import run.backend.domain.crew.dto.response.CrewUpcomingEventResponse;
+import run.backend.domain.crew.dto.response.EventResponseDto;
 import run.backend.domain.member.dto.request.MemberInfoRequest;
 import run.backend.domain.member.dto.response.MemberCrewStatusResponse;
 import run.backend.domain.member.dto.response.MemberInfoResponse;
@@ -66,9 +66,9 @@ public class MemberController {
 
     @GetMapping("/participated")
     @Operation(summary = "유저의 이번 시즌 참여한 러닝 리스트 조회", description = "유저가 이번 시즌에 참여한 러닝 리스트를 조회하는 API 입니다.")
-    public CommonResponse<CrewUpcomingEventResponse> getParticipated(@Login Member member) {
+    public CommonResponse<EventResponseDto> getParticipated(@Login Member member) {
 
-        CrewUpcomingEventResponse response = memberService.getParticipatedEvent(member);
+        EventResponseDto response = memberService.getParticipatedEvent(member);
         return new CommonResponse<>("러닝에 대한 상세 참여 내역 조회 성공", response);
     }
 }

--- a/src/main/java/run/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/run/backend/domain/member/controller/MemberController.java
@@ -3,8 +3,14 @@ package run.backend.domain.member.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import run.backend.domain.crew.dto.response.CrewUpcomingEventResponse;
 import run.backend.domain.member.dto.request.MemberInfoRequest;
 import run.backend.domain.member.dto.response.MemberCrewStatusResponse;
 import run.backend.domain.member.dto.response.MemberInfoResponse;
@@ -52,9 +58,17 @@ public class MemberController {
 
     @GetMapping("/participated/preview")
     @Operation(summary = "유저의 이번 시즌 참여 횟수 조회", description = "유저가 이번 달에 참여한 러닝 횟수를 조회하는 API 입니다.")
-    public CommonResponse<MemberParticipatedCountResponse> getMemberParticipatedCount(@Login Member member) {
+    public CommonResponse<MemberParticipatedCountResponse> getParticipatedCount(@Login Member member) {
 
-        MemberParticipatedCountResponse response = memberService.getMemberParticipatedCount(member);
+        MemberParticipatedCountResponse response = memberService.getParticipatedEventCount(member);
         return new CommonResponse<>("유저의 이번 시즌 참여 횟수 조회 성공", response);
+    }
+
+    @GetMapping("/participated")
+    @Operation(summary = "유저의 이번 시즌 참여한 러닝 리스트 조회", description = "유저가 이번 시즌에 참여한 러닝 리스트를 조회하는 API 입니다.")
+    public CommonResponse<CrewUpcomingEventResponse> getParticipated(@Login Member member) {
+
+        CrewUpcomingEventResponse response = memberService.getParticipatedEvent(member);
+        return new CommonResponse<>("러닝에 대한 상세 참여 내역 조회 성공", response);
     }
 }

--- a/src/main/java/run/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/run/backend/domain/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import org.springframework.web.multipart.MultipartFile;
 import run.backend.domain.member.dto.request.MemberInfoRequest;
 import run.backend.domain.member.dto.response.MemberCrewStatusResponse;
 import run.backend.domain.member.dto.response.MemberInfoResponse;
+import run.backend.domain.member.dto.response.MemberParticipatedCountResponse;
 import run.backend.domain.member.entity.Member;
 import run.backend.domain.member.service.MemberService;
 import run.backend.global.annotation.member.Login;
@@ -47,5 +48,13 @@ public class MemberController {
 
         MemberCrewStatusResponse response = memberService.getMembersCrewExists(member);
         return new CommonResponse<>("유저 크루 가입 여부 조회 완료", response);
+    }
+
+    @GetMapping("/participated/preview")
+    @Operation(summary = "유저의 이번 시즌 참여 횟수 조회", description = "유저가 이번 달에 참여한 러닝 횟수를 조회하는 API 입니다.")
+    public CommonResponse<MemberParticipatedCountResponse> getMemberParticipatedCount(@Login Member member) {
+
+        MemberParticipatedCountResponse response = memberService.getMemberParticipatedCount(member);
+        return new CommonResponse<>("유저의 이번 시즌 참여 횟수 조회 성공", response);
     }
 }

--- a/src/main/java/run/backend/domain/member/dto/response/MemberParticipatedCountResponse.java
+++ b/src/main/java/run/backend/domain/member/dto/response/MemberParticipatedCountResponse.java
@@ -4,6 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record MemberParticipatedCountResponse(
         @Schema(description = "유저의 이번 시즌 참여 횟수", example = "4")
-        String participatedCount
+        Long participatedCount
 ) {
 }

--- a/src/main/java/run/backend/domain/member/dto/response/MemberParticipatedCountResponse.java
+++ b/src/main/java/run/backend/domain/member/dto/response/MemberParticipatedCountResponse.java
@@ -1,0 +1,9 @@
+package run.backend.domain.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MemberParticipatedCountResponse(
+        @Schema(description = "유저의 이번 시즌 참여 횟수", example = "4")
+        String participatedCount
+) {
+}

--- a/src/main/java/run/backend/domain/member/service/MemberService.java
+++ b/src/main/java/run/backend/domain/member/service/MemberService.java
@@ -78,7 +78,7 @@ public class MemberService {
         List<JoinEvent> monthlyJoinEvents = joinEventRepository.findMonthlyParticipatedEvents(
                 member, monthRange.start(), monthRange.end());
 
-        String participatedCount = String.valueOf(monthlyJoinEvents.size());
+        Long participatedCount = (long) monthlyJoinEvents.size();
         return new MemberParticipatedCountResponse(participatedCount);
     }
 

--- a/src/main/java/run/backend/domain/member/service/MemberService.java
+++ b/src/main/java/run/backend/domain/member/service/MemberService.java
@@ -8,13 +8,20 @@ import run.backend.domain.crew.entity.Crew;
 import run.backend.domain.crew.entity.JoinCrew;
 import run.backend.domain.crew.enums.JoinStatus;
 import run.backend.domain.crew.repository.JoinCrewRepository;
+import run.backend.domain.event.entity.JoinEvent;
+import run.backend.domain.event.repository.JoinEventRepository;
 import run.backend.domain.file.service.FileService;
 import run.backend.domain.member.dto.request.MemberInfoRequest;
 import run.backend.domain.member.dto.response.MemberCrewStatusResponse;
 import run.backend.domain.member.dto.response.MemberInfoResponse;
+import run.backend.domain.member.dto.response.MemberParticipatedCountResponse;
 import run.backend.domain.member.entity.Member;
 import run.backend.domain.member.repository.MemberRepository;
+import run.backend.global.dto.DateRange;
+import run.backend.global.util.DateRangeUtil;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -25,6 +32,8 @@ public class MemberService {
     private final FileService fileService;
     private final MemberRepository memberRepository;
     private final JoinCrewRepository joinCrewRepository;
+    private final JoinEventRepository joinEventRepository;
+    private final DateRangeUtil dateRangeUtil;
 
     public MemberInfoResponse getMemberInfo(Member member) {
 
@@ -58,5 +67,17 @@ public class MemberService {
             return new MemberCrewStatusResponse("NONE");
         }
         return new MemberCrewStatusResponse(joinCrew.get().getJoinStatus().toString());
+    }
+
+    public MemberParticipatedCountResponse getMemberParticipatedCount(Member member) {
+
+        LocalDate today = LocalDate.now();
+        DateRange monthRange = dateRangeUtil.getMonthRange(today.getYear(), today.getMonthValue());
+
+        List<JoinEvent> monthlyJoinEvents = joinEventRepository.findMonthlyParticipatedEvents(
+                member, monthRange.start(), monthRange.end());
+
+        String participatedCount = String.valueOf(monthlyJoinEvents.size());
+        return new MemberParticipatedCountResponse(participatedCount);
     }
 }

--- a/src/main/java/run/backend/domain/member/service/MemberService.java
+++ b/src/main/java/run/backend/domain/member/service/MemberService.java
@@ -1,9 +1,14 @@
 package run.backend.domain.member.service;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import run.backend.domain.crew.dto.response.CrewUpcomingEventResponse;
+import run.backend.domain.crew.dto.response.EventProfileResponse;
 import run.backend.domain.crew.entity.Crew;
 import run.backend.domain.crew.entity.JoinCrew;
 import run.backend.domain.crew.enums.JoinStatus;
@@ -19,10 +24,6 @@ import run.backend.domain.member.entity.Member;
 import run.backend.domain.member.repository.MemberRepository;
 import run.backend.global.dto.DateRange;
 import run.backend.global.util.DateRangeUtil;
-
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -69,7 +70,7 @@ public class MemberService {
         return new MemberCrewStatusResponse(joinCrew.get().getJoinStatus().toString());
     }
 
-    public MemberParticipatedCountResponse getMemberParticipatedCount(Member member) {
+    public MemberParticipatedCountResponse getParticipatedEventCount(Member member) {
 
         LocalDate today = LocalDate.now();
         DateRange monthRange = dateRangeUtil.getMonthRange(today.getYear(), today.getMonthValue());
@@ -79,5 +80,16 @@ public class MemberService {
 
         String participatedCount = String.valueOf(monthlyJoinEvents.size());
         return new MemberParticipatedCountResponse(participatedCount);
+    }
+
+    public CrewUpcomingEventResponse getParticipatedEvent(Member member) {
+
+        LocalDate today = LocalDate.now();
+        DateRange monthRange = dateRangeUtil.getMonthRange(today.getYear(), today.getMonthValue());
+
+        List<EventProfileResponse> eventProfiles = joinEventRepository.findMonthlyCompletedEvents(
+                member, monthRange.start(), monthRange.end());
+
+        return new CrewUpcomingEventResponse(eventProfiles);
     }
 }

--- a/src/main/java/run/backend/domain/member/service/MemberService.java
+++ b/src/main/java/run/backend/domain/member/service/MemberService.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import run.backend.domain.crew.dto.response.CrewUpcomingEventResponse;
+import run.backend.domain.crew.dto.response.EventResponseDto;
 import run.backend.domain.crew.dto.response.EventProfileResponse;
 import run.backend.domain.crew.entity.Crew;
 import run.backend.domain.crew.entity.JoinCrew;
@@ -82,7 +82,7 @@ public class MemberService {
         return new MemberParticipatedCountResponse(participatedCount);
     }
 
-    public CrewUpcomingEventResponse getParticipatedEvent(Member member) {
+    public EventResponseDto getParticipatedEvent(Member member) {
 
         LocalDate today = LocalDate.now();
         DateRange monthRange = dateRangeUtil.getMonthRange(today.getYear(), today.getMonthValue());
@@ -90,6 +90,6 @@ public class MemberService {
         List<EventProfileResponse> eventProfiles = joinEventRepository.findMonthlyCompletedEvents(
                 member, monthRange.start(), monthRange.end());
 
-        return new CrewUpcomingEventResponse(eventProfiles);
+        return new EventResponseDto(eventProfiles);
     }
 }

--- a/src/test/java/run/backend/domain/crew/service/CrewEventServiceTest.java
+++ b/src/test/java/run/backend/domain/crew/service/CrewEventServiceTest.java
@@ -8,7 +8,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import run.backend.domain.crew.dto.common.DayStatusDto;
 import run.backend.domain.crew.dto.response.CrewMonthlyCanlendarResponse;
-import run.backend.domain.crew.dto.response.CrewUpcomingEventResponse;
+import run.backend.domain.crew.dto.response.EventResponseDto;
 import run.backend.domain.crew.dto.response.CrewWeeklyEventResponse;
 import run.backend.domain.crew.dto.response.EventProfileResponse;
 import run.backend.domain.crew.entity.Crew;
@@ -128,7 +128,7 @@ public class CrewEventServiceTest {
         when(eventMapper.toEventProfileList(events)).thenReturn(eventProfiles);
 
         // when
-        CrewUpcomingEventResponse response = crewEventService.getCrewUpcomingEvent(crew);
+        EventResponseDto response = crewEventService.getCrewUpcomingEvent(crew);
 
         // then
         assertThat(response.eventProfiles()).isEqualTo(eventProfiles);

--- a/src/test/java/run/backend/domain/event/service/EventServiceTest.java
+++ b/src/test/java/run/backend/domain/event/service/EventServiceTest.java
@@ -233,7 +233,7 @@ class EventServiceTest {
 
             // then
             then(eventRepository).should().findById(1L);
-            then(joinEventRepository).should(never()).deleteByEventAndMember(any(), any());
+            then(joinEventRepository).should(never()).delete(any());
         }
 
         @Test
@@ -289,9 +289,8 @@ class EventServiceTest {
 
             // then
             then(joinEventRepository).should().findByEventAndMember(savedEvent, runningCaptain);
+            then(joinEventRepository).should().delete(savedJoinEvent);
             then(joinEventRepository).should().save(any(JoinEvent.class));
-
-            assertThat(savedJoinEvent.getDeletedAt()).isNotNull();
         }
 
         @Test
@@ -315,8 +314,8 @@ class EventServiceTest {
             sut.updateEvent(1L, request);
 
             // then
+            then(joinEventRepository).should().delete(savedJoinEvent);
             assertThat(savedEvent.getMember()).isEqualTo(newCaptain);
-            assertThat(savedJoinEvent.getDeletedAt()).isNotNull();
         }
 
         @Test
@@ -354,7 +353,7 @@ class EventServiceTest {
             sut.updateEvent(1L, request);
 
             // then
-            assertThat(savedPeriodicEvent.getDeletedAt()).isNotNull();
+            then(periodicEventRepository).should().delete(savedPeriodicEvent);
         }
 
         @Test
@@ -488,7 +487,7 @@ class EventServiceTest {
         void shouldReturnExpectedParticipantsBeforeEvent() {
             //given
             given(eventRepository.findById(1L)).willReturn(Optional.of(savedEvent));
-            given(joinEventRepository.findByEventAndNotDeleted(any())).willReturn(List.of(savedJoinEvent));
+            given(joinEventRepository.findByEvent(any())).willReturn(List.of(savedJoinEvent));
             given(joinEventRepository.findActualParticipantsByEvent(any())).willReturn(List.of(savedJoinEvent));
 
             //when
@@ -496,7 +495,7 @@ class EventServiceTest {
 
             //then
             then(eventRepository).should().findById(1L);
-            then(joinEventRepository).should().findByEventAndNotDeleted(any());
+            then(joinEventRepository).should().findByEvent(any());
             then(joinEventRepository).should(never()).findActualParticipantsByEvent(any());
         }
 
@@ -505,7 +504,7 @@ class EventServiceTest {
         void shouldReturnActualParticipantsAfterEvent() {
             //given
             given(eventRepository.findById(1L)).willReturn(Optional.of(completedEvent));
-            given(joinEventRepository.findByEventAndNotDeleted(any())).willReturn(List.of(savedJoinEvent));
+            given(joinEventRepository.findByEvent(any())).willReturn(List.of(savedJoinEvent));
             given(joinEventRepository.findActualParticipantsByEvent(any())).willReturn(List.of(savedJoinEvent));
 
             //when
@@ -513,7 +512,7 @@ class EventServiceTest {
 
             //then
             then(eventRepository).should().findById(1L);
-            then(joinEventRepository).should(never()).findByEventAndNotDeleted(any());
+            then(joinEventRepository).should(never()).findByEvent(any());
             then(joinEventRepository).should().findActualParticipantsByEvent(any());
         }
 
@@ -529,7 +528,7 @@ class EventServiceTest {
 
             //then
             then(eventRepository).should().findById(1L);
-            then(joinEventRepository).should(never()).findByEventAndNotDeleted(any());
+            then(joinEventRepository).should(never()).findByEvent(any());
             then(joinEventRepository).should(never()).findActualParticipantsByEvent(any());
         }
     }
@@ -545,7 +544,7 @@ class EventServiceTest {
             
             given(eventRepository.findById(1L)).willReturn(Optional.of(savedEvent));
             given(joinEventRepository.save(any())).willReturn(savedJoinEvent);
-            given(joinEventRepository.existsByEventAndMemberAndDeletedAtIsNull(any(),any())).willReturn(false);
+            given(joinEventRepository.existsByEventAndMember(any(),any())).willReturn(false);
             given(eventMapper.toJoinEvent(any(Event.class), any(Member.class)))
                 .willReturn(savedJoinEvent);
 
@@ -565,7 +564,7 @@ class EventServiceTest {
             Long initialExpectedParticipants = savedEvent.getExpectedParticipants();
 
             given(eventRepository.findById(1L)).willReturn(Optional.of(savedEvent));
-            given(joinEventRepository.existsByEventAndMemberAndDeletedAtIsNull(any(),any())).willReturn(true);
+            given(joinEventRepository.existsByEventAndMember(any(),any())).willReturn(true);
 
             //when & then
             assertThatThrownBy(() -> sut.joinEvent(1L, requestMember))
@@ -595,7 +594,6 @@ class EventServiceTest {
             Long initialExpectedParticipants = savedEvent.getExpectedParticipants();
 
             given(eventRepository.findById(1L)).willReturn(Optional.of(savedEvent));
-            given(joinEventRepository.save(any())).willReturn(savedJoinEvent);
             given(joinEventRepository.findByEventAndMember(any(), any())).willReturn(Optional.of(savedJoinEvent));
 
             //when
@@ -603,7 +601,7 @@ class EventServiceTest {
 
             //then
             then(eventRepository).should().findById(1L);
-            then(joinEventRepository).should().save(any());
+            then(joinEventRepository).should().delete(savedJoinEvent);
             assertThat(savedEvent.getExpectedParticipants()).isEqualTo(initialExpectedParticipants - 1);
         }
 
@@ -614,7 +612,7 @@ class EventServiceTest {
             Long initialExpectedParticipants = savedEvent.getExpectedParticipants();
 
             given(eventRepository.findById(1L)).willReturn(Optional.of(savedEvent));
-            given(joinEventRepository.existsByEventAndMemberAndDeletedAtIsNull(any(),any())).willReturn(true);
+            given(joinEventRepository.findByEventAndMember(any(), any())).willReturn(Optional.empty());
 
             //when & then
             assertThatThrownBy(() -> sut.cancelJoinEvent(1L, requestMember))

--- a/src/test/java/run/backend/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/run/backend/domain/member/service/MemberServiceTest.java
@@ -19,7 +19,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
-import run.backend.domain.crew.dto.response.CrewUpcomingEventResponse;
+import run.backend.domain.crew.dto.response.EventResponseDto;
 import run.backend.domain.crew.dto.response.EventProfileResponse;
 import run.backend.domain.crew.entity.Crew;
 import run.backend.domain.crew.entity.JoinCrew;
@@ -221,7 +221,7 @@ public class MemberServiceTest {
                     .willReturn(eventProfiles);
 
             // when
-            CrewUpcomingEventResponse response = sut.getParticipatedEvent(testMember);
+            EventResponseDto response = sut.getParticipatedEvent(testMember);
 
             // then
             assertThat(response.eventProfiles()).hasSize(2);
@@ -245,7 +245,7 @@ public class MemberServiceTest {
                     .willReturn(List.of());
 
             // when
-            CrewUpcomingEventResponse response = sut.getParticipatedEvent(testMember);
+            EventResponseDto response = sut.getParticipatedEvent(testMember);
 
             // then
             assertThat(response.eventProfiles()).isEmpty();

--- a/src/test/java/run/backend/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/run/backend/domain/member/service/MemberServiceTest.java
@@ -1,33 +1,44 @@
 package run.backend.domain.member.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.web.multipart.MultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import run.backend.domain.crew.dto.response.CrewUpcomingEventResponse;
+import run.backend.domain.crew.dto.response.EventProfileResponse;
 import run.backend.domain.crew.entity.Crew;
 import run.backend.domain.crew.entity.JoinCrew;
 import run.backend.domain.crew.enums.JoinStatus;
 import run.backend.domain.crew.repository.JoinCrewRepository;
-import run.backend.domain.file.service.FileService;
-import run.backend.domain.member.dto.request.MemberInfoRequest;
+import run.backend.domain.event.entity.JoinEvent;
+import run.backend.domain.event.repository.JoinEventRepository;
 import run.backend.domain.member.dto.response.MemberCrewStatusResponse;
 import run.backend.domain.member.dto.response.MemberInfoResponse;
+import run.backend.domain.member.dto.response.MemberParticipatedCountResponse;
 import run.backend.domain.member.entity.Member;
 import run.backend.domain.member.enums.Gender;
 import run.backend.domain.member.enums.OAuthType;
 import run.backend.domain.member.repository.MemberRepository;
-
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.*;
+import run.backend.global.dto.DateRange;
+import run.backend.global.util.DateRangeUtil;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("MemberService")
 public class MemberServiceTest {
 
     @Mock
@@ -36,37 +47,52 @@ public class MemberServiceTest {
     @Mock
     private JoinCrewRepository joinCrewRepository;
 
+    @Mock
+    private JoinEventRepository joinEventRepository;
+
+    @Mock
+    private DateRangeUtil dateRangeUtil;
+
     @InjectMocks
-    private MemberService memberService;
+    private MemberService sut; // System Under Test
 
     private Member testMember;
     private Crew testCrew;
-
-    private MemberInfoRequest data;
 
     @BeforeEach
     public void setUp() {
 
         // member
-        testMember = spy(Member.builder()
-                .username("test username")
-                .oauthId("test id")
-                .oauthType(OAuthType.GOOGLE)
-                .profileImage("test image")
-                .build());
+        testMember = createMemberWithId(1L, "테스트사용자");
 
         // crew
-        testCrew = spy(Crew.builder()
-                .name("test crew name")
-                .description("크루 소개 테스트")
-                .image("test image url")
-                .build());
+        testCrew = createCrew("테스트크루");
+    }
 
-        // memberInfoRequest
-        data = new MemberInfoRequest(
-                Gender.FEMALE,
-                20,
-                "newNickname");
+    private Member createMemberWithId(Long id, String nickname) {
+        Member member = Member.builder()
+                .username("test_user")
+                .nickname(nickname)
+                .gender(Gender.MALE)
+                .age(25)
+                .oauthId("oauth_id_" + id)
+                .oauthType(OAuthType.GOOGLE)
+                .profileImage("profile.jpg")
+                .build();
+
+        ReflectionTestUtils.setField(member, "id", id);
+        return member;
+    }
+
+    private Crew createCrew(String name) {
+        Crew crew = Crew.builder()
+                .name(name)
+                .description("테스트 크루 설명")
+                .image("crew.jpg")
+                .build();
+
+        ReflectionTestUtils.setField(crew, "id", 1L);
+        return crew;
     }
 
     @Test
@@ -78,7 +104,7 @@ public class MemberServiceTest {
                 .thenReturn(Optional.of(testCrew));
 
         // when
-        MemberInfoResponse response = memberService.getMemberInfo(testMember);
+        MemberInfoResponse response = sut.getMemberInfo(testMember);
 
         // then
         assertEquals(testMember.getNickname(), response.nickName());
@@ -93,7 +119,7 @@ public class MemberServiceTest {
         when(joinCrewRepository.findByMember(member)).thenReturn(Optional.empty());
 
         // When
-        MemberCrewStatusResponse response = memberService.getMembersCrewExists(member);
+        MemberCrewStatusResponse response = sut.getMembersCrewExists(member);
 
         // Then
         assertEquals("NONE", response.status());
@@ -109,9 +135,140 @@ public class MemberServiceTest {
         when(joinCrewRepository.findByMember(member)).thenReturn(Optional.of(joinCrew));
 
         // When
-        MemberCrewStatusResponse response = memberService.getMembersCrewExists(member);
+        MemberCrewStatusResponse response = sut.getMembersCrewExists(member);
 
         // Then
         assertEquals("APPROVED", response.status());
+    }
+
+    @Nested
+    @DisplayName("getParticipatedEventCount 메서드는")
+    class GetParticipatedEventCountTest {
+
+        @Test
+        @DisplayName("이번 달 참여한 이벤트 개수를 반환한다")
+        void shouldReturnMonthlyParticipatedEventCount() {
+            // given
+            LocalDate today = LocalDate.now();
+            DateRange monthRange = new DateRange(
+                    today.withDayOfMonth(1),
+                    today.withDayOfMonth(today.lengthOfMonth())
+            );
+
+            JoinEvent joinEvent1 = createJoinEvent(1L);
+            JoinEvent joinEvent2 = createJoinEvent(2L);
+            List<JoinEvent> monthlyJoinEvents = List.of(joinEvent1, joinEvent2);
+
+            given(dateRangeUtil.getMonthRange(today.getYear(), today.getMonthValue()))
+                    .willReturn(monthRange);
+            given(joinEventRepository.findMonthlyParticipatedEvents(
+                    testMember, monthRange.start(), monthRange.end()))
+                    .willReturn(monthlyJoinEvents);
+
+            // when
+            MemberParticipatedCountResponse response = sut.getParticipatedEventCount(testMember);
+
+            // then
+            assertThat(response.participatedCount()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("참여한 이벤트가 없을 때 0을 반환한다")
+        void shouldReturnZeroWhenNoParticipatedEvents() {
+            // given
+            LocalDate today = LocalDate.now();
+            DateRange monthRange = new DateRange(
+                    today.withDayOfMonth(1),
+                    today.withDayOfMonth(today.lengthOfMonth())
+            );
+
+            given(dateRangeUtil.getMonthRange(today.getYear(), today.getMonthValue()))
+                    .willReturn(monthRange);
+            given(joinEventRepository.findMonthlyParticipatedEvents(
+                    testMember, monthRange.start(), monthRange.end()))
+                    .willReturn(List.of());
+
+            // when
+            MemberParticipatedCountResponse response = sut.getParticipatedEventCount(testMember);
+
+            // then
+            assertThat(response.participatedCount()).isEqualTo(0);
+        }
+    }
+
+    @Nested
+    @DisplayName("getParticipatedEvent 메서드는")
+    class GetParticipatedEventTest {
+
+        @Test
+        @DisplayName("이번 달 완료된 이벤트 목록을 반환한다")
+        void shouldReturnMonthlyCompletedEvents() {
+            // given
+            LocalDate today = LocalDate.now();
+            DateRange monthRange = new DateRange(
+                    today.withDayOfMonth(1),
+                    today.withDayOfMonth(today.lengthOfMonth())
+            );
+
+            EventProfileResponse eventProfile1 = createEventProfileResponse(1L, "러닝 이벤트 1");
+            EventProfileResponse eventProfile2 = createEventProfileResponse(2L, "러닝 이벤트 2");
+            List<EventProfileResponse> eventProfiles = List.of(eventProfile1, eventProfile2);
+
+            given(dateRangeUtil.getMonthRange(today.getYear(), today.getMonthValue()))
+                    .willReturn(monthRange);
+            given(joinEventRepository.findMonthlyCompletedEvents(
+                    testMember, monthRange.start(), monthRange.end()))
+                    .willReturn(eventProfiles);
+
+            // when
+            CrewUpcomingEventResponse response = sut.getParticipatedEvent(testMember);
+
+            // then
+            assertThat(response.eventProfiles()).hasSize(2);
+            assertThat(response.eventProfiles()).containsExactly(eventProfile1, eventProfile2);
+        }
+
+        @Test
+        @DisplayName("완료된 이벤트가 없을 때 빈 목록을 반환한다")
+        void shouldReturnEmptyListWhenNoCompletedEvents() {
+            // given
+            LocalDate today = LocalDate.now();
+            DateRange monthRange = new DateRange(
+                    today.withDayOfMonth(1),
+                    today.withDayOfMonth(today.lengthOfMonth())
+            );
+
+            given(dateRangeUtil.getMonthRange(today.getYear(), today.getMonthValue()))
+                    .willReturn(monthRange);
+            given(joinEventRepository.findMonthlyCompletedEvents(
+                    testMember, monthRange.start(), monthRange.end()))
+                    .willReturn(List.of());
+
+            // when
+            CrewUpcomingEventResponse response = sut.getParticipatedEvent(testMember);
+
+            // then
+            assertThat(response.eventProfiles()).isEmpty();
+        }
+    }
+
+    private JoinEvent createJoinEvent(Long eventId) {
+        JoinEvent joinEvent = JoinEvent.builder()
+                .member(testMember)
+                .build();
+
+        ReflectionTestUtils.setField(joinEvent, "id", eventId);
+        return joinEvent;
+    }
+
+    private EventProfileResponse createEventProfileResponse(Long eventId, String title) {
+        return new EventProfileResponse(
+                eventId,
+                title,
+                LocalDate.now(),
+                LocalTime.of(9, 0),
+                LocalTime.of(10, 0),
+                5L
+        );
     }
 }


### PR DESCRIPTION
## ✨ 연관된 이슈
> close #33 

<br>

## 📝 작업 내용 (주요 변경 사항)
- 유저의 이번 시즌 참여 횟수 조회 API
- 유저의 이번 시즌 참여 러닝 리스트 조회 API

<br>

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

러닝 리스트 응답이 CrewUpcomingEventResponse 이거랑 같아서 우선 이걸로 썼는데 따로 만들까요?
아니면 이름을 공통으로 사용할 수 있게 변경하는게 좋을까요?

